### PR TITLE
config/routes.rb for redmine stable-1.4

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,4 @@
+
+ActionController::Routing::Routes.draw do |map|
+    map.connect 'questions/:action/:id', :controller => 'questions'
+end


### PR DESCRIPTION
this re-activates the formerly magic routes see: http://www.redmine.org/projects/redmine/wiki/Plugin_Tutorial#Generating-a-controller

(Starting from 1.4.0, Redmine won't provide anymore the default
wildcard route (':controller/:action/:id'). Plugins will have to
declare the routes they need in their proper config/routes.rb file.)
